### PR TITLE
Dev environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ plugins: [
   {
     resolve: 'gatsby-plugin-intercom-spa',
     options: {
-      app_id: 'YOUR_INTERCOM_APP_ID'
+      app_id: 'YOUR_INTERCOM_APP_ID',
+      include_in_development: true,
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-intercom-spa",
   "description": "Gatsby plugin to add intercom onto a site",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "author": "Tal Bereznitskey <berzniz@gmail.com>",
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,6 @@
 exports.onInitialClientRender = () => {
-  if (process.env.NODE_ENV === `production` && typeof Intercom === `function` && window.IntercomAppId) {
+  var includeInDevelopment = window.IntercomIncludeInDevelopment === undefined ? false : window.IntercomIncludeInDevelopment
+  if ((includeInDevelopment || process.env.NODE_ENV === `production`) && typeof Intercom === `function` && window.IntercomAppId) {
     window.Intercom("boot", {
       app_id: window.IntercomAppId
     });
@@ -7,7 +8,8 @@ exports.onInitialClientRender = () => {
 }
 
 exports.onRouteUpdate = function({ location }) {
-  if (process.env.NODE_ENV === `production` && typeof Intercom === `function` && window.IntercomAppId) {
+  var includeInDevelopment = window.IntercomIncludeInDevelopment === undefined ? false : window.IntercomIncludeInDevelopment
+  if ((includeInDevelopment || process.env.NODE_ENV === `production`) && typeof Intercom === `function` && window.IntercomAppId) {
     window.Intercom("update");
   }
 }

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,13 +1,15 @@
 import React from "react"
 
 exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
-  if (process.env.NODE_ENV === `production`) {
+  var includeInDevelopment = pluginOptions.include_in_development === undefined ? false : pluginOptions.include_in_development;
+  if (includeInDevelopment || process.env.NODE_ENV === `production`) {
     return setPostBodyComponents([
       <script
         key={`gatsby-plugin-intercom-spa`}
         dangerouslySetInnerHTML={{
           __html: `
           window.IntercomAppId = '${pluginOptions.app_id}';
+          window.IntercomIncludeInDevelopment = ${includeInDevelopment};
           (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/${pluginOptions.app_id}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
           `,
         }}


### PR DESCRIPTION
## Background

We recently integrated [Intercom](https://www.intercom.com/) into our website. We had many questions and did not totally know what to expect. After deciding to use `gatsby-plugin-intercom` rather than manually include the JavaScript in our own components, we spent some time trying to troubleshoot why the Intercom messenger wasn't working. 

We, as a rule of thumb, never push code to production which hasn't been tested. This meant that we were working purely locally. After digging into the plugin source, we found that there was a production environment check which was causing the plugin to be excluded when running `gatsby develop`.

## Analysis of Problem

People familiar with Intercom and this particular plugin wouldn't have been tripped up by this. **However**, integrating the `gatsby-plugin-intercom` plugin is something that you tend to do only once. That means, there are two types of users:

1. Complete newbies, which can be easily confused by the dev environment exclusion (in this example: us)
2. People who have integrated the plugin and will never touch it again

## Suggestion

Add an `include_in_development` option which defaults to true:

```javascript
plugins: [
  {
    resolve: `gatsby-plugin-intercom`,
    options: {
      app_id: 'YOUR_INTERCOM_APP_ID',
      include_in_development: true,
    },
  },
]
```

There appears to be no good reason to exclude the [Intercom](https://www.intercom.com/) plugin from the development environment, and it would save a lot of potential integration headaches if it was enabled by default. We suggest adding a configurable option which defaults to true.

This allows for:
1. Painless, works-out-of-the-box configuration for newbies
2. Full configuration for those who have already installed and are familiar with the plugin

## State of Pull Request

- ✅ Suggested changes included in pull request
- ✅ Changes tested
- ✅ Documentation updated
- ✅ Version number bumped to 0.1.0 on account of a public API change
- ❌ Published